### PR TITLE
Lovendringsforslag: Definer funksjonstiden for tillitsvalgte

### DIFF
--- a/lover.rst
+++ b/lover.rst
@@ -514,6 +514,9 @@ a) Generalforsamlingen er foreningens høyeste myndighet i spørsmål som
    flertall. Oppnår ingen dette ved første avstemming, avholdes bundet
    omvalg.
 
+#) Tillitsvalgte har funksjonstid fra 1. januar til 30. juni på
+   vårsemesteret og fra 1. juli til 31. desember på høstsemesteret.
+
 #) På ordinær generalforsamling behandles:
 
    1. Regnskaper, etter en redegjørelse for RFs totale økonomi.

--- a/lover.rst
+++ b/lover.rst
@@ -298,7 +298,7 @@ a) Desisjonsutvalget har tre medlemmer: Det velges ett medlem på den
    ordinære generalforsamlingen i hvert semester, og funksjonstiden er
    tre semestre.
 
-#) Valgbare er alle tidligere tillitsvalgte som nevnt i § 24 l.
+#) Valgbare er alle tidligere tillitsvalgte som nevnt i § 24 m.
 
 #) Desisjonsutvalgets medlemmer kan ikke samtidig være medlemmer av
    noen andre av de faste styrer, utvalg eller komiteer nevnt i § 7,
@@ -489,7 +489,7 @@ a) Generalforsamlingen er foreningens høyeste myndighet i spørsmål som
 #) Generalforsamlingen kan foreta endringer i rekkefølgen av punktene
    til det endelige forslag til dagsorden. Den kan også utelukke ett
    eller flere av de foreslåtte punkter så lenge det ikke strider mot
-   § 24 l. Den endelige dagsorden godkjennes av
+   § 24 m. Den endelige dagsorden godkjennes av
    generalforsamlingen. I forbindelse med godkjennelse av dagsorden
    skal det velges ordstyrer, referent og to medlemmer til å
    undertegne generalforsamlingens protokoll.
@@ -552,7 +552,7 @@ a) Generalforsamlingen er foreningens høyeste myndighet i spørsmål som
 --------------
 
 Foreningens medlemmer kan fremme mistillitsforslag mot tillitsvalgte
-som er valgt ihht. § 24 l punkt 6, unntatt Desisjonsutvalget. Slike
+som er valgt ihht. § 24 m punkt 6, unntatt Desisjonsutvalget. Slike
 forslag kan bare behandles av en generalforsamling, og må være fremmet
 48 timer før generalforsamlingen. Mistillitsforslag vedtas med 2/3
 flertall. Dersom mistillitsforslaget mot et medlem av et organ blir


### PR DESCRIPTION
Begrunnelse:

I dag velger vi tillitsvalgte for et eller flere semester om gangen, men det er ikke definert hvor lenge et semester varer. Dette skaper unødvendig komplikasjoner i overgangsperioden mellom to styrer ettersom det kan bli uklart hvem som har ansvar. Dette lovforslaget gjør det veldig klart hvem som har ansvar ved å si at funksjonstiden er akkurat 6 måneder.

Merk at dette lovendringsforslaget legger ingen begrensninger på hva det nye styret planlegger/gjennomfører før semesteret starter, og det gamle styret står fortsatt fritt til å delegere arbeidsoppgaver til det nye styret.