### PR TITLE
Endret tittel på § 13 fra Blæstgruppa til Blæststyret

### DIFF
--- a/lover.rst
+++ b/lover.rst
@@ -207,7 +207,7 @@ a) Fagstyret ledes av fagsjef, og har følgende andre medlemmer:
    informasjon til Økonomiutvalget og overholde vedtatte budsjetter.
 
 
-§ 13 BLÆSTGRUPPA
+§ 13 BLÆSTSTYRET
 ----------------
 
 a) Blæststyret ledes av blæstsjef, og har følgende andre medlemmer:


### PR DESCRIPTION
Alle referanser i lovverket har ordlyden "blæststyret". Jeg har derfor også endret dette for overskriften til § 13.