### PR TITLE
lovendring fra Oscar Halse. Vedtatt V23

### DIFF
--- a/lover-regi.rst
+++ b/lover-regi.rst
@@ -2,7 +2,7 @@
    RF-REGIS LOVER
 ===============================
 ------------------------
-Vedtatt 18. april 2018
+Vedtatt 19. april 2023
 ------------------------
 
 
@@ -62,9 +62,9 @@ a)  Styret i RF-Regi består av: regiformann, forretningsfører, DJ-sjef og Real
 
 #)  Regiformann velges på vårens generalforsamling og sitter for ett år. Regiformann er foreningens daglige leder og styreleder.
 
-#)  Forretningsfører velges på høstens generalforsamling og sitter for ett år. Forretningsfører er ansvarlig for foreningens økonomi og er foreningens nestleder.
+#)  Forretningsfører velges på høstens generalforsamling og sitter for ett år. Forretningsfører er ansvarlig for foreningens økonomi.
 
-#)  Utleieansvarlig velges på generalforsamling og sitter for ett semester. Utleieansvarlig har overordnet ansvar for drift av RF-Regis utleievirksomhet.
+#)  Utleieansvarlig velges på generalforsamling og sitter for ett semester. Utleieansvarlig har overordnet ansvar for drift av RF-Regis utleievirksomhet og er foreningens nestleder.
 
 #)  DJ-sjef velges på generalforsamling og sitter for ett semester. DJ-sjef er ansvarlig for daglig drift av DJ-gruppen.
 


### PR DESCRIPTION
Begrunnelse:
I praksis er Regi nå for tida en utleieforening som rigger for RF på si, heller enn motsatt. Derfor syntes jeg det er helt naturlig at det finnes en fast plass i styret til utleieansvarlig. 

Historisk sett har dette vært et verv som fordeles av styret. Tanken har så vidt jeg har forstått vært at en da ikke risikerer å ikke få et fulltallig styre på genfors og man må slite seg gjennom ekstraordinære osv. Det er altså mer fleksibelt og ikke ha utleieansvarlig som et valgt verv.

Men utleieansvarlig er en såpass sentral og stor arbeidsoppgave i Regi at jeg tror dette blir en for stor fleksibilitet. Det er uheldig å sende et signal om at utleieansvar er noe som kan taes lett på å fordeles senere, og implisitt kan droppes like lett. Utleieansvar så er det et såpass viktig verv at det burde få vekten tilknyttet å være et valgt styreverv. 