### PR TITLE
Lovendring fra Christina Eide. vedtatt H23

### DIFF
--- a/lover.rst
+++ b/lover.rst
@@ -2,7 +2,7 @@
    REALISTFORENINGENS LOVER
 ===============================
 ----------------------
-Vedtatt 9. nov 2022
+Vedtatt 22. nov 2023
 ----------------------
 
 
@@ -490,7 +490,9 @@ a) Generalforsamlingen er foreningens høyeste myndighet i spørsmål som
 
 #) Ethvert medlem kan på generalforsamlingen foreslå tatt opp saker
    utenom den oppsatte dagsorden. Generalforsamlingen kan ikke fatte
-   vedtak i slike saker.
+   vedtak i slike saker. Dersom Generalforsamlingen ser det som nødvnedig
+   å fatte vedtak i slike saker kan dagsorden åpnet med 2/3 flertall før
+   saken påbegynnes
 
 #) Generalforsamlingen kan med alminnelig flertall gi ikke-medlemmer
    møte- og talerett.


### PR DESCRIPTION
Begrunnelse:

Dette er standard kotyme i flere organisasjoner og har som hensikt at dersom det er noe som kommer opp i løpet av generalforsamlingen som krever at man trenger å gjøre vedtak eller velge inn en person, vil man kunne gjøre dette uten å vente til neste generalforsamling. Saker som ikke trenger vedtak kan tas under eventuelt som vanlig. Generalforsamlingen som organ er organisasjonens øverste myndighet og kan gjøre det aller meste, og ved å kreve 2/3 flertall vil det være vanskligere å missbruke det enn ved alminnelig flertall. 2/3 er også det samme kravet som ved lovendringer. 
