### PR TITLE
lovendring fra Frida Rasmussen. Vedtatt H23

### DIFF
--- a/lover.rst
+++ b/lover.rst
@@ -2,7 +2,7 @@
    REALISTFORENINGENS LOVER
 ===============================
 ----------------------
-Vedtatt 9. nov 2022
+Vedtatt 22. nov 2023
 ----------------------
 
 
@@ -149,7 +149,7 @@ a) Hovedstyret har følgende stemmeberettigede medlemmer: formann,
 
 #) Hovedstyret oppnevner alle verv. Som verv er å regne: 
    skjenkemester, utlånsansvarlig, vaktmester, populærvitenskapelig 
-   ansvarlig, bedriftskontakt, donaldsjef, vaktgruppeleder, 
+   ansvarlig, bedriftskontakt, donaldsjef, vaktgruppesjef, 
    arrangementsmester, internansvarlig, vevmester, panikkansvarlig,
    husbjørnredaktør, baffelmester, korsjef, hoveddirigent og kormester. 
    Hovedstyret kan oppnevne andre verv etter behov. Hovedstyret kan avsette 
@@ -188,7 +188,7 @@ a) Hovedstyret har følgende stemmeberettigede medlemmer: formann,
 -----------------------
 
 a) Arrangementsstyret ledes av arrangementssjef, og har følgende andre
-   medlemmer: regiformann, blæstsjef, vaktgruppeleder,
+   medlemmer: regiformann, blæstsjef, vaktgruppesjef,
    arrangementsmestere og kjellermester.
 
 #) Arrangementsstyret er ansvarlig for planlegging, koordinering og
@@ -236,7 +236,7 @@ a) Blæststyret ledes av blæstsjef, og har følgende andre medlemmer:
 
 a) Kjellerstyret ledes av kjellermester, og har følgende andre
    medlemmer: kafesjef, utlånsansvarlig, skjenkemestere, vaktmester,
-   baffelmestere og vaktgruppeleder.
+   baffelmestere og vaktgruppesjef.
 
 #) Kjellerstyret har ansvaret for den daglige drift av
    RF-kjelleren. Dette omfatter også utlån og vedlikehold av lokalene.
@@ -360,7 +360,7 @@ a) Revisjonsutvalget har tre medlemmer: Det velges ett medlem på den
 § 19 VAKTGRUPPA
 ---------------
 
-a) Vaktgruppa ledes av vaktgruppeleder som utpekes av Hovedstyret etter
+a) Vaktgruppa ledes av vaktgruppesjef som utpekes av Hovedstyret etter
    innstilling fra Vaktgruppa.
 
 #) Vaktgruppas oppgave er i samråd med Arrangementstyret og


### PR DESCRIPTION
Jeg har et endringsforslag som gjelder leder av vaktgruppa sin tittel. Dette står i §11 f og §19 a i RFs lover. 

Jeg ønsker å endre vaktgruppeleders tittel
Fra: vaktgruppeleder
Til: vaktgruppesjef

Begrunnelse:
Jeg fremmer dette forslaget på bakgrunn av at alle andre gruppeledere i denne foreningen (med unntak av Kjellermester og ØU-leder) tituleres med «sjef». Jeg ønsker å endre tittelen tilbake til vaktgruppesjef da dette er den termen de fleste, inkludert vaktgruppa selv, bruker internt. Dette gjør også at titlene på gruppelederne i foreningen vår blir mer konsekvente. 