### PR TITLE
Krav til godkjent regnskap i ØU før man kan stille til RU

### DIFF
--- a/lover.rst
+++ b/lover.rst
@@ -2,7 +2,7 @@
    REALISTFORENINGENS LOVER
 ===============================
 ----------------------
-Vedtatt 9. nov 2022
+Vedtatt 17. april 2024
 ----------------------
 
 
@@ -341,10 +341,10 @@ a) Revisjonsutvalget har tre medlemmer: Det velges ett medlem på den
    ordinære generalforsamlingen i hvert semester, og funksjonstiden er
    tre semestre.
 
-#) Revisjonsutvalgets medlemmer kan ikke samtidig være medlem av noen andre
-   av de faste styrer og utvalg nevnt i § 7 a–h, komiteer nevnt i § 8,
+#) Revisjonsutvalgets medlemmer kan ikke samtidig være medlem av noen andre 
+   av de faste styrer og utvalg nevnt i § 7 a–h, komiteer nevnt i § 8, 
    RF-Regis styre (§ 22) eller Biørnegildestyret (§ 23), inneha verv nevnt i § 11 f eller ha vært medlem av 
-   Økonomiutvalget foregående to semestre.
+   Økonomiutvalget i tidligere semester hvor regnskapet ikke er godkjent av generalforsamlingen
 
 #) Revisjonsutvalgets oppgave er å revidere Realistforeningens
    regnskaper. Minst to av revisjonsutvalgets medlemmer må delta i


### PR DESCRIPTION
Endring foreslått av Maximiliano Horta.
Begrunnelse:
Per i dag er det mulig å sitte i ØU, ikke få godkjent regnskapet sitt på 2 semestere; stille til RevisjonsUtvalget (RU) og være med å anbefale godkjenning av sitt eget regnskapet til generalforsamlingen semesteret etterpå. Dette er ikke helt heldig og noe vi burde få fikset på et eller annet vis.

Kommentar fra DU:
Desisjonsutvalget ser det slik at gjeldende lovtekst ble utformet på bakgrunn av en forventning om at regnskapet for foregående år skulle bli godkjent innen to semestre. Dette for å hindre at et tidligere ØU-medlem skulle være inhabil i godkjenningen av et regnskap de selv har vært med på å utarbeide. Dette endringsforslaget ivaretar denne intensjonen bedre og Desisjonsutvalget anbefaler derfor generalforsamlinga å vedta dette forslaget.